### PR TITLE
Change name filter

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -7,7 +7,7 @@ data "aws_ami" "amazon_linux" {
     name = "name"
 
     values = [
-      "amzn-ami-hvm-*-x86_64-gp2",
+      "amzn2-ami-*-hvm-*-x86_64-gp2",
     ]
   }
 


### PR DESCRIPTION
Change name filter to match new AWS AMI image names, as we now should use Amazon Linux 2. Amazon Linux 1 reached end of life. Additional details can be found here- https://aws.amazon.com/blogs/aws/update-on-amazon-linux-ami-end-of-life/